### PR TITLE
Broadcast_impl_serialized returns when size == 0 instead of size == 1.

### DIFF
--- a/MPI/Communicator.cs
+++ b/MPI/Communicator.cs
@@ -1346,8 +1346,6 @@ namespace MPI
 
         private void Broadcast_impl_serialized<T>(bool isRoot, ref T value, int root)
         {
-            if (Size == 0)
-                return;  // no one to broadcast to
             SpanTimer.Enter("Broadcast");
             using (UnmanagedMemoryStream stream = new UnmanagedMemoryStream())
             {

--- a/MPI/Communicator.cs
+++ b/MPI/Communicator.cs
@@ -1346,7 +1346,7 @@ namespace MPI
 
         private void Broadcast_impl_serialized<T>(bool isRoot, ref T value, int root)
         {
-            if (Size == 1)
+            if (Size == 0)
                 return;  // no one to broadcast to
             SpanTimer.Enter("Broadcast");
             using (UnmanagedMemoryStream stream = new UnmanagedMemoryStream())


### PR DESCRIPTION
This corrects the issue described here: https://github.com/Microsoft/MPI.NET/issues/3