### PR TITLE
remove MPIUTILS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,6 @@ AC_CONFIG_FILES([MPI/MPI.dll.config Tests/runtest.sh],[],[])
 
 AC_OUTPUT([
 Makefile
-MPIUtils/Makefile
 MPI/Makefile
 TestCommons/Makefile
 Examples/Makefile


### PR DESCRIPTION
Addressing https://github.com/microsoft/MPI.NET/issues/10 to enable installation on linux 