### PR TITLE
Remove remaining makefile dependencies on MPIUtils

### DIFF
--- a/MPI/Makefile.am
+++ b/MPI/Makefile.am
@@ -15,7 +15,8 @@ if MPINET_CBRIDGE
 lib_LTLIBRARIES = libmpinet.la
 endif
 
-SOURCES=$(srcdir)/Attribute.cs			\
+SOURCES=$(srcdir)/ActionStream.cs		\
+	$(srcdir)/Attribute.cs			\
 	$(srcdir)/CartesianCommunicator.cs	\
 	$(srcdir)/Communicator.cs		\
 	$(srcdir)/Comparison.cs			\
@@ -26,9 +27,12 @@ SOURCES=$(srcdir)/Attribute.cs			\
 	$(srcdir)/Group.cs			\
 	$(srcdir)/Intercommunicator.cs		\
 	$(srcdir)/Intracommunicator.cs		\
+	$(srcdir)/Memory.cs			\
 	$(srcdir)/Operation.cs			\
 	$(srcdir)/Request.cs			\
 	$(srcdir)/RequestList.cs		\
+	$(srcdir)/Serialization.cs		\
+	$(srcdir)/SpanTimer.cs			\
 	$(srcdir)/Status.cs			\
 	$(srcdir)/TagAllocator.cs		\
 	$(srcdir)/TopologicalCommunicator.cs	\
@@ -40,8 +44,8 @@ pkglibexec_SCRIPTS = MPI.dll MPI.dll.config
 EXTRA_DIST = $(SOURCES) Unsafe.cs Unsafe.pl MPI.dll.config.in
 CLEANFILES = MPI.dll CustomUnsafe.cs cbridge.c
 
-MPI.dll: $(SOURCES) CustomUnsafe.cs ../MPIUtils/MPIUtils.dll 
-	$(MCS) -out:$@ -unsafe -target:library -lib:../MPIUtils -reference:MPIUtils.dll $(CSHARP_FLAGS) $(SOURCES) CustomUnsafe.cs 
+MPI.dll: $(SOURCES) CustomUnsafe.cs
+	$(MCS) -out:$@ -unsafe -target:library $(CSHARP_FLAGS) $(SOURCES) CustomUnsafe.cs
 
 CustomUnsafe.cs cbridge.c: $(srcdir)/Unsafe.cs $(srcdir)/Unsafe.pl $(MPI_HEADER)
 	$(PERL) $(srcdir)/Unsafe.pl $(MPI_HEADER) $(srcdir)/Unsafe.cs CustomUnsafe.cs cbridge.c @DEFS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@
 #  
 # Authors: Douglas Gregor
 #          Andrew Lumsdaine
-SUBDIRS = MPIUtils MPI TestCommons Examples Benchmarks Tests 
+SUBDIRS = MPI TestCommons Examples Benchmarks Tests
 
 EXTRA_DIST=LICENSE_1_0.txt README.txt
 


### PR DESCRIPTION
Removes Makefile dependencies on MPIUtils. Some source files also appeared to be missing from one of the Makefiles, but it is possible that they were previously accounted for by MPIUtils.
With this change, I was able to build the solution on ubuntu 22.04 (should address #10).
Please let me know if there is any other information I should provide!